### PR TITLE
Added support for the Cordova Facebook SDK.

### DIFF
--- a/core-services/facebook.js
+++ b/core-services/facebook.js
@@ -14,11 +14,11 @@ if (Meteor.isClient) {
     //if (Meteor.isCordova) {
     // Meteor.isCordova is broken on Ionic 2 + meteor-client-bundle
     if (typeof facebookConnectPlugin != "undefined") {
-      if (!Package['darkbasic:accounts-facebook-cordova']) {
-        throw new Meteor.Error(403, 'Please include darkbasic:accounts-facebook-cordova package or cordova-fb package')
+      if (!Package['btafel:accounts-facebook-cordova']) {
+        throw new Meteor.Error(403, 'Please include btafel:accounts-facebook-cordova package or cordova-fb package')
       }
     } else {
-      if ((!Package['accounts-facebook'] && !Package['darkbasic:accounts-facebook-cordova']) || !facebookPackage) {
+      if ((!Package['accounts-facebook'] && !Package['btafel:accounts-facebook-cordova']) || !facebookPackage) {
         throw new Meteor.Error(403, 'Please include accounts-facebook and facebook-oauth package or cordova-fb package')
       }
     }

--- a/link_accounts_server.js
+++ b/link_accounts_server.js
@@ -27,6 +27,64 @@ Accounts.registerLoginHandler(function (options) {
       result.serviceName, result.serviceData, result.options);
 });
 
+Accounts.registerLoginHandler(function(loginRequest) {
+  if(!loginRequest.cordovaLink) {
+    return undefined;
+  }
+
+  loginRequest = loginRequest.authResponse;
+
+  var whitelisted = ['id', 'email', 'name', 'first_name',
+    'last_name', 'link', 'gender', 'locale', 'age_range'];
+
+  var identity = getIdentity(loginRequest.accessToken, whitelisted);
+
+  var profilePicture = getProfilePicture(loginRequest.accessToken);
+
+  var serviceData = {
+    accessToken: loginRequest.accessToken,
+    expiresAt: (+new Date) + (1000 * loginRequest.expiresIn)
+  };
+
+
+  var fields = _.pick(identity, whitelisted);
+  _.extend(serviceData, fields);
+
+  var options = {profile: {}};
+  var profileFields = _.pick(identity, Meteor.settings.public.facebook.profileFields);
+  _.extend(options.profile, profileFields);
+
+  options.profile.avatar = profilePicture;
+
+  return Accounts.LinkUserFromExternalService("facebook", serviceData, options);
+  //return Accounts.updateOrCreateUserFromExternalService("facebook", serviceData, options);
+
+});
+
+var getIdentity = function (accessToken, fields) {
+  try {
+    return HTTP.get("https://graph.facebook.com/me", {
+      params: {
+        access_token: accessToken,
+        fields: fields.join(",")
+      }
+    }).data;
+  } catch (err) {
+    throw _.extend(new Error("Failed to fetch identity from Facebook. " + err.message),
+      {response: err.response});
+  }
+};
+
+var getProfilePicture = function (accessToken) {
+  try {
+    return HTTP.get("https://graph.facebook.com/v2.0/me/picture/?redirect=false", {
+      params: {access_token: accessToken}}).data.data.url;
+  } catch (err) {
+    throw _.extend(new Error("Failed to fetch identity from Facebook. " + err.message),
+      {response: err.response});
+  }
+};
+
 Accounts.LinkUserFromExternalService = function (serviceName, serviceData, options) {
   options = _.clone(options || {});
 


### PR DESCRIPTION
 Added support for the Cordova Facebook SDK. Also using 'typeof facebookConnectPlugin' instead of Meteor.isCordova because the latter is broken on Ionic 2 + meteor-client-bundle.

I also switched to 'darkbasic:accounts-facebook-cordova' because of [this](https://github.com/btafel/accounts-facebook/pull/2), but you can easily revert it.