### PR TITLE
Changed linkedIn oauth package for LinkedIn api V2

### DIFF
--- a/community-services/linkedin.js
+++ b/community-services/linkedin.js
@@ -5,8 +5,8 @@ Meteor.linkWithLinkedIn = function(options, callback) {
   if (!Meteor.userId()) {
     throw new Meteor.Error(402, 'Please login to an existing account before link.');
   }
-  if (!Package['jonperl:linkedin']) {
-    throw new Meteor.Error(403, 'Please include jonperl:linkedin package');
+  if (!Package['pauli:linkedin-oauth']) {
+    throw new Meteor.Error(403, 'Please include pauli:linkedin-oauth package');
   }
 
   if (!callback && typeof options === 'function') {
@@ -15,5 +15,5 @@ Meteor.linkWithLinkedIn = function(options, callback) {
   }
 
   const credentialRequestCompleteCallback = Accounts.oauth.linkCredentialRequestCompleteHandler(callback);
-  Package['jonperl:linkedin'].LinkedIn.requestCredential(options, credentialRequestCompleteCallback);
+  Package['pauli:linkedin-oauth'].LinkedIn.requestCredential(options, credentialRequestCompleteCallback);
 };


### PR DESCRIPTION
Previous Oauth package for LinkedIn wasn't working anymore due to deprecated V1 API in LinkedIn

I changed the needed package for this, from `jonperl:linkedin` to `pauli:linkedin-oauth`