### PR TITLE
Fix linking with Office 365

### DIFF
--- a/community-services/office365.js
+++ b/community-services/office365.js
@@ -5,7 +5,7 @@ Meteor.linkWithOffice = function (options, callback) {
   if (!Meteor.userId()) {
     throw new Meteor.Error(402, 'Please login to an existing account before link.')
   }
-  if (!Package['lindoelio:accounts-office365'] || !Package['ermlab:accounts-office365']) {
+  if (!Package['lindoelio:accounts-office365'] && !Package['ermlab:accounts-office365']) {
     throw new Meteor.Error(403, 'Please include either lindoelio:accounts-office365 package or ermlab:accounts-office365 package.')
   }
 
@@ -15,9 +15,5 @@ Meteor.linkWithOffice = function (options, callback) {
   }
 
   const credentialRequestCompleteCallback = Accounts.oauth.linkCredentialRequestCompleteHandler(callback)
-  if (Package['lindoelio:accounts-office365']) {
-    Package['lindoelio:accounts-office365'].Office365.requestCredential(options, credentialRequestCompleteCallback)
-  } else if (Package['ermlab:accounts-office365']) {
-    Package['ermlab:accounts-office365'].Office365.requestCredential(options, credentialRequestCompleteCallback)
-  }
+  Office365.requestCredential(options, credentialRequestCompleteCallback)
 }


### PR DESCRIPTION
Addresses two issues preventing Office 365 integration from working. Fixed in this PR:
* Require only one version of `accounts-office365`
* Correctly use `Office365` global variable added by accounts-office365

I did a quick run through with a test account to verify that it works after the above changes.